### PR TITLE
solves: secondary attributes are not displayed in 'edit view' panel

### DIFF
--- a/app/src/server/view_edit.R
+++ b/app/src/server/view_edit.R
@@ -961,7 +961,7 @@ observe({
 
     variables <- mxDbGetLayerColumnsNames(
       table = layerMain,
-      notIn = c("geom","gid",'mx_t0','mx_t1','_mx_valid')
+      notIn = c("geom","gid",'_mx_valid')
       )
 
     geomType <- .get(viewData,c("data","geometry","type"))


### PR DESCRIPTION
Secondary attributes were no more displayed in 'edit view' panel when mx_t0 or/and mx_t1 were selected. This mainly affected the vector tiles views with dashboards.