### PR TITLE
Fix toolbar toolbox button switch

### DIFF
--- a/app/src/js/mx_helper_map_controls.js
+++ b/app/src/js/mx_helper_map_controls.js
@@ -197,6 +197,7 @@ mapControlApp.prototype.onAdd = function(map) {
       action: () => {
         h.panelLeftSwitch({
           id: 'panel-views',
+          panel: 'views',
           toggle: true
         });
       }
@@ -208,6 +209,7 @@ mapControlApp.prototype.onAdd = function(map) {
       action: () => {
         h.panelLeftSwitch({
           id: 'panel-tools',
+          panel: 'tools',
           toggle: true
         });
       }


### PR DESCRIPTION
On the current master branch stat the toolbar toolbox button switches the views panel instead of the toolbox panel.
![Peek 2020-03-24 17-42](https://user-images.githubusercontent.com/875021/77453675-d79d9580-6df7-11ea-9686-67dfa6ce503d.gif)
