### PR TITLE
Allow to test sdk by group(s)

### DIFF
--- a/app/src/js/sdk/src/testing.js
+++ b/app/src/js/sdk/src/testing.js
@@ -87,7 +87,10 @@ export class Testing {
     if (opt.ignore) {
       return;
     }
-    if (!t._is_in_groups(opt.group)) {
+    if (!t._is_in_opt_set('titles', title)) {
+      return;
+    }
+    if (!t._is_in_opt_set('groups', opt.group)) {
       return;
     }
 
@@ -249,12 +252,12 @@ export class Testing {
     };
   }
 
-  _is_in_groups(group) {
+  _is_in_opt_set(set, value) {
     let out = false;
-    if (this.opt.groups.length === 0) {
+    if (this.opt[set] !== undefined && this.opt[set].length === 0) {
       out = true;
-    } else if (group !== undefined) {
-      out = this.opt.groups.includes(group);
+    } else if (value !== undefined) {
+      out = this.opt[set].includes(value);
     }
     return out;
   }

--- a/app/src/js/sdk/src/testing.js
+++ b/app/src/js/sdk/src/testing.js
@@ -84,9 +84,6 @@ export class Testing {
   check(title, opt) {
     const t = this;
     opt = Object.assign({}, defaultsTests, opt);
-    if (opt.ignore) {
-      return;
-    }
     if (!t._is_in_opt_set('titles', title)) {
       return;
     }

--- a/app/src/js/sdk/src/testing.js
+++ b/app/src/js/sdk/src/testing.js
@@ -3,7 +3,8 @@ import * as is from '../../is_test/index.js';
 
 const defaults = {
   title: 'test',
-  container: document.body
+  container: document.body,
+  groups: []
 };
 const defaultsTests = {
   tests: [],
@@ -84,6 +85,9 @@ export class Testing {
     const t = this;
     opt = Object.assign({}, defaultsTests, opt);
     if (opt.ignore) {
+      return;
+    }
+    if (!t._is_in_groups(opt.group)) {
       return;
     }
 
@@ -243,5 +247,15 @@ export class Testing {
       text: elText,
       timing: elTiming
     };
+  }
+
+  _is_in_groups(group) {
+    let out = false;
+    if (this.opt.groups.length === 0) {
+      out = true;
+    } else if (group !== undefined) {
+      out = this.opt.groups.includes(group);
+    }
+    return out;
   }
 }

--- a/app/src/js/sdk/tests/index.js
+++ b/app/src/js/sdk/tests/index.js
@@ -16,7 +16,14 @@ mapx.on('message', (message) => {
     console.info(`%c 🤬 ${message.text}`, 'color: #F00');
   }
 });
-const t = new mxsdk.Testing({container: elResults, title: 'mapx sdk test'});
+
+const groups = (new window.URL(window.location.href)).searchParams.get('groups')
+const t = new mxsdk.Testing({
+  container: elResults,
+  title: 'mapx sdk test',
+  groups: groups ? groups.split(',') : [],
+});
+
 const ignoreGlobal = false;
 const ignoreNot = false;
 /**

--- a/app/src/js/sdk/tests/index.js
+++ b/app/src/js/sdk/tests/index.js
@@ -17,11 +17,13 @@ mapx.on('message', (message) => {
   }
 });
 
-const groups = (new window.URL(window.location.href)).searchParams.get('groups')
+const groups = (new window.URL(window.location.href)).searchParams.get('groups');
+const titles = (new window.URL(window.location.href)).searchParams.get('titles');
 const t = new mxsdk.Testing({
   container: elResults,
   title: 'mapx sdk test',
   groups: groups ? groups.split(',') : [],
+  titles:  titles ? titles.split(',') : [],
 });
 
 const ignoreGlobal = false;

--- a/app/src/js/sdk/tests/index.js
+++ b/app/src/js/sdk/tests/index.js
@@ -26,15 +26,12 @@ const t = new mxsdk.Testing({
   titles:  titles ? titles.split(',') : [],
 });
 
-const ignoreGlobal = false;
-const ignoreNot = false;
 /**
  * MapX respond
  */
 mapx.once('ready', () => {
 
   t.check('Get list methods', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_sdk_methods');
     },
@@ -48,7 +45,6 @@ mapx.once('ready', () => {
     ]
   });
   t.check('Get views list', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_views');
     },
@@ -63,7 +59,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Trigger login window', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('show_modal_login');
     },
@@ -83,7 +78,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get / Set language', {
-    ignore: ignoreGlobal,
     tests: [
       {
         name: 'test if the language is set',
@@ -101,7 +95,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get views id list', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_views_id');
     },
@@ -116,7 +109,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get views with active layers on map', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', ['vt', 'rt']);
       await mapx.ask('view_add', {idView: view.id});
@@ -144,7 +136,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Set view order', {
-    ignore: ignoreGlobal,
     init: async () => {
       await mapx.ask('set_views_list_sort', {asc: true, mode: 'text'});
       const viewsOrder = await mapx.ask('get_views_order');
@@ -165,7 +156,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view vt attribute meta', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', 'vt');
       const meta = await mapx.ask('get_view_meta_vt_attribute', {
@@ -184,7 +174,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view table attribute config', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', 'vt');
       const config = await mapx.ask('get_view_table_attribute_config', {
@@ -203,7 +192,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view table attribute url', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', 'vt');
       const url = await mapx.ask('get_view_table_attribute_url', {
@@ -222,7 +210,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view table attribute', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', 'vt');
       const data = await mapx.ask('get_view_table_attribute', {
@@ -241,7 +228,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view vt source meta', {
-    ignore: ignoreGlobal,
     init: async () => {
       // jshint ignore:start
       const view = await mapx.ask('_get_random_view', 'vt');
@@ -262,7 +248,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view rt or vt legend', {
-    ignore: ignoreGlobal,
     init: async () => {
       const h = t.h;
       const view = await mapx.ask('_get_random_view', ['vt', 'rt'], (v) => {
@@ -288,7 +273,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get view meta', {
-    ignore: ignoreGlobal,
     timeout: 10000,
     init: async () => {
       const view = await mapx.ask('_get_random_view');
@@ -305,7 +289,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get user id', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_user_id');
     },
@@ -320,7 +303,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get user ip', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_user_ip');
     },
@@ -335,7 +317,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get user roles', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_user_roles');
     },
@@ -350,7 +331,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get user email', {
-    ignore: ignoreGlobal,
     init: async () => {
       const isGuest = await mapx.ask('is_user_guest');
       if (isGuest) {
@@ -369,7 +349,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Filter view by text', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', 'vt', (v) => {
         return v.data.attribute && v.data.attribute.type;
@@ -407,7 +386,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get collection by project', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_project_collections');
     },
@@ -422,7 +400,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Set dashboard visibility', {
-    ignore: ignoreGlobal,
     init: async () => {
       const views = await mapx.ask('get_views');
       const view = views.find((v) => {
@@ -455,7 +432,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Get collection of open views', {
-    ignore: ignoreGlobal,
     init: async () => {
       const views = await mapx.ask('get_views');
       const view = views.find((v) => {
@@ -487,7 +463,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Load projects', {
-    ignore: ignoreGlobal,
     init: () => {
       return mapx.ask('get_projects');
     },
@@ -519,7 +494,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Show edit view modal', {
-    ignore: ignoreGlobal,
     init: async () => {
       const project = await mapx.ask('get_project');
       const view = await mapx.ask('_get_random_view', null, (v) => {
@@ -557,7 +531,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Trigger map composer', {
-    ignore: ignoreGlobal,
     init: async () => {
       return mapx.ask('show_modal_map_composer');
     },
@@ -577,7 +550,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Trigger download view source : vt', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', ['vt']);
       await mapx.ask('download_view_source_vector', {
@@ -601,7 +573,6 @@ mapx.once('ready', () => {
   });
 
   t.check('GeoJSON: create view, download geojson data', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('view_geojson_create', {
         random: {n: 100},
@@ -634,7 +605,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Trigger share module for a view', {
-    ignore: ignoreGlobal,
     init: async () => {
       const view = await mapx.ask('_get_random_view', ['vt', 'rt', 'sm', 'cc']);
       await mapx.ask('show_modal_share', {
@@ -658,7 +628,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Tools - trigger sharing manager', {
-    ignore :ignoreGlobal,
     init: async () => {
       return mapx.ask('show_modal_tool', {tool: 'sharing_manager'});
     },
@@ -681,7 +650,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Tools - add new view', {
-    ignore : ignoreGlobal,
     init: async () => { 
       return await mapx.ask('show_modal_tool', {tool: 'view_new'});
     },
@@ -704,7 +672,6 @@ mapx.once('ready', () => {
   });
 
   t.check('Tools - validate source geom', {
-    ignore : ignoreGlobal,
     init: async () => {
       return await mapx.ask('show_modal_tool', {tool: 'source_validate_geom'});
     },


### PR DESCRIPTION
Simple solution to test by group; add a `group` key:
```js
  t.check('Get views list', {
    ignore: ignoreGlobal,
    group: 'foo'
    init: () => {
      return mapx.ask('get_views');
    },
    tests: [
      {
        name: 'is array of views',
        test: (r) => {
          return t.h.isArrayOfViews(r);
        }
      }
    ]
  });
```

Then, add the query string as follow: `http://127.0.0.1:8080/?groups=foo,bar`