### PR TITLE
Add missing xtail to app service image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 FROM fredmoser/debian_r3.5.1_shinyserver1.5.7.890
 
-
+RUN apt-get update && apt-get install xtail -y
 
 # Overwrite SockJSAdapter.R by a custom version:
 # Remove _ga refs


### PR DESCRIPTION
App service fail in 'start_mapx.sh' script:
```
app_1        | /usr/bin/start_mapx.sh: 65: exec: xtail: not found
```