### PR TITLE
API: fixes an issue  with data classification (see #629)

### DIFF
--- a/api/modules/template/sql/getSourceSummary_attr_continuous.sql
+++ b/api/modules/template/sql/getSourceSummary_attr_continuous.sql
@@ -63,12 +63,7 @@ classes AS (
   FROM bins b, attr_min amin, attr_max amax, attr_bin_max abinmax
 ),
 bin_vmin_count AS (
-  SELECT
-  CASE
-    WHEN count(a.from) = 1
-    THEN TRUE
-    ELSE FALSE
-  END AS bin_vmin_unique
+  SELECT count(a.from) = 1 AS bin_vmin_unique
   FROM classes a, attr_min amin
   WHERE a.from = amin.min
 ),
@@ -85,7 +80,7 @@ freqtable AS (
       WHEN b.from = b.to
       THEN
         a."{{idAttr}}" = b.from AND a."{{idAttr}}" = b.to
-      WHEN b.from < b.to AND b.from = amin.min AND bvminc.bin_vmin_unique 
+      WHEN b.from < b.to AND b.from = amin.min AND bvminc.bin_vmin_unique
       THEN 
         a."{{idAttr}}" >= b.from AND a."{{idAttr}}" <= b.to
       ELSE

--- a/api/modules/template/sql/getSourceSummary_attr_continuous.sql
+++ b/api/modules/template/sql/getSourceSummary_attr_continuous.sql
@@ -1,39 +1,39 @@
 WITH
-attr_max as (
+attr_max AS (
   SELECT
-  max("{{idAttr}}")::numeric
+  MAX("{{idAttr}}")::NUMERIC
   FROM "{{idSource}}"
 ),
-attr_min as (
+attr_min AS (
   SELECT
-  min("{{idAttr}}")::numeric
+  MIN("{{idAttr}}")::NUMERIC
   FROM "{{idSource}}"
 ),
-attr_array as (
-  SELECT array_agg("{{idAttr}}"::numeric) as agg 
+attr_array AS (
+  SELECT array_agg("{{idAttr}}"::NUMERIC) AS agg 
   FROM "{{idSource}}" 
 ),
-bins as (
+bins AS (
   -- return and array. e.g. {81742.142857142857,163484.285714285714,245226.428571428571,326968.571428571428,408710.714285714285,490452.857142857142,572194.999999999999}
   SELECT
   CASE
-  WHEN '{{binsMethod}}' = 'jenks'
-    THEN CDB_JenksBins( agg , {{binsNumber}})
-  WHEN '{{binsMethod}}' = 'quantile'
-    THEN CDB_QuantileBins( agg , {{binsNumber}})
-  WHEN '{{binsMethod}}' = 'heads_tails'
-    THEN CDB_HeadsTailsBins( agg , {{binsNumber}})
-  WHEN '{{binsMethod}}' = 'equal_interval'
-    THEN  CDB_EqualIntervalBins( agg , {{binsNumber}})
-END as bins
-FROM attr_array
+    WHEN '{{binsMethod}}' = 'jenks'
+    THEN CDB_JenksBins(agg, {{binsNumber}})
+    WHEN '{{binsMethod}}' = 'quantile'
+    THEN CDB_QuantileBins(agg, {{binsNumber}})
+    WHEN '{{binsMethod}}' = 'heads_tails'
+    THEN CDB_HeadsTailsBins(agg, {{binsNumber}})
+    WHEN '{{binsMethod}}' = 'equal_interval'
+    THEN  CDB_EqualIntervalBins(agg, {{binsNumber}})
+  END AS bins
+  FROM attr_array
 ),
-attr_bin_max as (
+attr_bin_max AS (
   -- workaround to find largest value in bins, as heads_tails and 
   -- equal_interval do not always use max as the max bin
-  SELECT MAX(b) max FROM ( SELECT unnest(bins) b from bins) ub
+  SELECT MAX(b) max FROM (SELECT unnest(bins) b FROM bins) ub
 ),
-classes as (
+classes AS (
   -- return a table such as
   --        from         |         to
   --- --------------------+---------------------
@@ -49,42 +49,52 @@ classes as (
   SELECT
   unnest(
     array_remove(
-      array_prepend(amin.min,b.bins),
+      array_prepend(amin.min, b.bins),
       abinmax.max
     )
-  ) as "from" ,
+  ) AS "from" ,
   -- remove max bin class, add real max class as last 'to' class, unnest
   unnest(
     array_append(
     array_remove(b.bins, abinmax.max),
     amax.max
    )
-  ) as "to"
+  ) AS "to"
   FROM bins b, attr_min amin, attr_max amax, attr_bin_max abinmax
 ),
-freqtable as (
+bin_vmin_count AS (
+  SELECT
+  CASE
+    WHEN count(a.from) = 1
+    THEN TRUE
+    ELSE FALSE
+  END AS bin_vmin_unique
+  FROM classes a, attr_min amin
+  WHERE a.from = amin.min
+),
+freqtable AS (
   SELECT 
   "from", 
   "to", 
-  ( "to" - "from" )  as diff, 
+  ("to" - "from") AS diff, 
   (
     SELECT count(*) 
     FROM "{{idSource}}" a 
     WHERE 
     CASE
-    WHEN b.from = b.to
+      WHEN b.from = b.to
       THEN
         a."{{idAttr}}" = b.from AND a."{{idAttr}}" = b.to
-    WHEN b.from > b.to AND b.from = amin.min
+      WHEN b.from < b.to AND b.from = amin.min AND bvminc.bin_vmin_unique 
       THEN 
         a."{{idAttr}}" >= b.from AND a."{{idAttr}}" <= b.to
       ELSE
         a."{{idAttr}}" > b.from AND a."{{idAttr}}" <= b.to
-  END
-) as count
-FROM classes b, attr_min amin, attr_max amax
+    END
+) AS count
+FROM classes b, attr_min amin, attr_max amax, bin_vmin_count bvminc
 ),
-freqtable_json as (
+freqtable_json AS (
   SELECT json_agg(
     json_build_object(
       'from', ft.from, 
@@ -92,7 +102,7 @@ freqtable_json as (
       'diff', ft.diff, 
       'count',ft.count
     ) 
-  ) as freq_array
+  ) AS freq_array
   FROM freqtable ft
 )
 
@@ -107,7 +117,7 @@ SELECT json_build_object(
     'binsNumber',{{binsNumber}},
     'table', to_json(ft.freq_array)
   )
-) as res
+) AS res
 FROM
 attr_max, 
 attr_min, 


### PR DESCRIPTION
Fixes the following issues:
- the minimum value was not included in the first rule
- if the minimum value was included in more than one rule, it was counted multiple times

In addition, these changes should be completed by an additional validation rule for this route (if possible): `binsNumbers` <= number of features.