### PR TITLE
fix(map): carry gradient background hotfix into staging

### DIFF
--- a/app/src/css/mx_modifiers.css
+++ b/app/src/css/mx_modifiers.css
@@ -130,6 +130,22 @@ input {
 .mx .maplibregl-canvas {
   outline: none;
 }
+
+.mx .maplibregl-map {
+  background-image: radial-gradient(
+    circle,
+    #8297a3,
+    #707b86,
+    #5c6169,
+    #48494c,
+    #323232
+  );
+}
+
+.mx .maplibregl-canvas {
+  background-color: transparent;
+}
+
 .mx .mx-modal-container,
 .mx .selectize-dropdown,
 .mx .maplibregl-popup-content {


### PR DESCRIPTION
## Summary
- carry the production map-container gradient fix into the 1.14.1 alpha line
- keep the MapLibre canvas background transparent

This PR contains only the CSS commit from the production hotfix. It intentionally excludes all `1.14.0-fix.1` release and changelog files.

## Validation
- same CSS patch manually verified for the production hotfix
- `npm run test:app` passed on the production branch
- `git diff --check` passed